### PR TITLE
Update locallib.php

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -25,6 +25,8 @@
  * @license    MIT
  */
 
+require_once($CFG->libdir . '/filelib.php');
+
 defined('MOODLE_INTERNAL') || die();
 require_once(dirname(__FILE__)."/lib.php");
 


### PR DESCRIPTION
when upgrading the sales moodle server we got this error.  this line fixes that so that `$curl = new curl();` will work.
